### PR TITLE
ci: auto-tag and release on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,23 +2,60 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always
   BIN: sshinto
 
 jobs:
+  tag:
+    name: Create and push tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      created: ${{ steps.tag.outputs.created }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag (skip if already exists)
+        id: tag
+        run: |
+          VERSION="v${{ steps.version.outputs.version }}"
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists — skipping release."
+            echo "created=false" >> $GITHUB_OUTPUT
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "$VERSION"
+            git push origin "$VERSION"
+            echo "created=true" >> $GITHUB_OUTPUT
+          fi
+
   changelog:
     name: Generate changelog
     runs-on: ubuntu-latest
+    needs: tag
+    if: needs.tag.outputs.created == 'true'
     outputs:
       release_body: ${{ steps.cliff.outputs.content }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: "v${{ needs.tag.outputs.version }}"
 
       - name: Generate changelog with git-cliff
         uses: orhun/git-cliff-action@v4
@@ -30,7 +67,8 @@ jobs:
   build:
     name: Build — ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    needs: changelog
+    needs: tag
+    if: needs.tag.outputs.created == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +96,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "v${{ needs.tag.outputs.version }}"
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -93,7 +133,7 @@ jobs:
         if: matrix.archive == 'tar.gz'
         shell: bash
         run: |
-          ASSET="${{ env.BIN }}-${{ github.ref_name }}-${{ matrix.target }}.tar.gz"
+          ASSET="${{ env.BIN }}-v${{ needs.tag.outputs.version }}-${{ matrix.target }}.tar.gz"
           cp target/${{ matrix.target }}/release/${{ env.BIN }} .
           tar -czf "$ASSET" ${{ env.BIN }}
           echo "ASSET=$ASSET" >> $GITHUB_ENV
@@ -102,7 +142,7 @@ jobs:
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          $asset = "${{ env.BIN }}-${{ github.ref_name }}-${{ matrix.target }}.zip"
+          $asset = "${{ env.BIN }}-v${{ needs.tag.outputs.version }}-${{ matrix.target }}.zip"
           Copy-Item "target/${{ matrix.target }}/release/${{ env.BIN }}.exe" .
           Compress-Archive -Path "${{ env.BIN }}.exe" -DestinationPath $asset
           "ASSET=$asset" | Out-File -FilePath $env:GITHUB_ENV -Append
@@ -117,7 +157,7 @@ jobs:
   release:
     name: Publish release
     runs-on: ubuntu-latest
-    needs: [changelog, build]
+    needs: [tag, changelog, build]
     permissions:
       contents: write
     steps:
@@ -130,6 +170,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: "v${{ needs.tag.outputs.version }}"
           body: ${{ needs.changelog.outputs.release_body }}
           files: artefacts/*
           fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary
- Release pipeline now triggers on push to `main` instead of tag push
- Reads version from `Cargo.toml` automatically
- Creates and pushes the tag from within the pipeline
- Skips the release silently if the tag already exists (no duplicate releases)

## Flow
1. Bump version in `Cargo.toml`, merge to `main`
2. `tag` job reads the version, creates `vX.Y.Z`, pushes it
3. `changelog` + `build` jobs run in parallel against that tag
4. `release` job publishes the GitHub release with all artefacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)